### PR TITLE
Fix bitbucketserver eof

### DIFF
--- a/applicationset/services/scm_provider/bitbucket_server.go
+++ b/applicationset/services/scm_provider/bitbucket_server.go
@@ -3,6 +3,7 @@ package scm_provider
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/argoproj/argo-cd/v2/applicationset/utils"
 	bitbucketv1 "github.com/gfleury/go-bitbucket-v1"
@@ -183,8 +184,9 @@ func (b *BitbucketServerProvider) listBranches(repo *Repository) ([]bitbucketv1.
 
 func (b *BitbucketServerProvider) getDefaultBranch(org string, repo string) (*bitbucketv1.Branch, error) {
 	response, err := b.client.DefaultApi.GetDefaultBranch(org, repo)
-	// The API will return 404 if a default branch is set but doesn't exist or nil in case the default branch is not set (empty repo)
-	if (response != nil && response.StatusCode == 404) || (response == nil) {
+	// The API will return 404 if a default branch is set but doesn't exist. In case the repo is empty and default branch is unset,
+	// we will get an EOF and a nil response.
+	if (response != nil && response.StatusCode == 404) || (response == nil && err == io.EOF) {
 		return nil, nil
 	}
 	if err != nil {

--- a/applicationset/services/scm_provider/bitbucket_server.go
+++ b/applicationset/services/scm_provider/bitbucket_server.go
@@ -183,8 +183,8 @@ func (b *BitbucketServerProvider) listBranches(repo *Repository) ([]bitbucketv1.
 
 func (b *BitbucketServerProvider) getDefaultBranch(org string, repo string) (*bitbucketv1.Branch, error) {
 	response, err := b.client.DefaultApi.GetDefaultBranch(org, repo)
-	if response != nil && response.StatusCode == 404 {
-		// There's no default branch i.e. empty repo, not an error
+	// The API will return 404 if a default branch is set but doesn't exist or nil in case the default branch is not set (empty repo)
+	if (response != nil && response.StatusCode == 404) || (response == nil) {
 		return nil, nil
 	}
 	if err != nil {

--- a/applicationset/services/scm_provider/bitbucket_server_test.go
+++ b/applicationset/services/scm_provider/bitbucket_server_test.go
@@ -365,6 +365,28 @@ func TestGetBranchesMissingDefault(t *testing.T) {
 	assert.Empty(t, repos)
 }
 
+func TestGetBranchesEmptyRepo(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+		switch r.RequestURI {
+		case "/rest/api/1.0/projects/PROJECT/repos/REPO/branches/default":
+			return
+		}
+	}))
+	defer ts.Close()
+	provider, err := NewBitbucketServerProviderNoAuth(context.Background(), ts.URL, "PROJECT", false)
+	assert.NoError(t, err)
+	repos, err := provider.GetBranches(context.Background(), &Repository{
+		Organization: "PROJECT",
+		Repository:   "REPO",
+		URL:          "ssh://git@mycompany.bitbucket.org/PROJECT/REPO.git",
+		Labels:       []string{},
+		RepositoryId: 1,
+	})
+	assert.Empty(t, repos)
+	assert.NoError(t, err)
+}
+
 func TestGetBranchesErrorDefaultBranch(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Empty(t, r.Header.Get("Authorization"))


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
